### PR TITLE
Add init_channels/0 function

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ config :simple_client, SimpleClient,
 defmodule SimpleClient do
   use Pushest, otp_app: :simple_client
 
+  # Subscribe to these channels right after application startup.
+  def init_channels do
+    [
+      [name: "public-init-channel", user_data: %{}],
+      [name: "private-init-channel", user_data: %{}],
+      [name: "presence-init-channel", user_data: %{user_id: 123}],
+    ]
+  end
+
   # handle_event/2 is user-defined callback which is triggered whenever an event
   # occurs on the channel.
   def handle_event({:ok, "public-channel", "some-event"}, frame) do

--- a/README.md
+++ b/README.md
@@ -56,12 +56,16 @@ defmodule SimpleClient do
 
   # handle_event/2 is user-defined callback which is triggered whenever an event
   # occurs on the channel.
+  def handle_event({:ok, "public-init-channel", "some-event"}, frame) do
+    # do something with public-init-channel frame
+  end
+
   def handle_event({:ok, "public-channel", "some-event"}, frame) do
-    # do something with public frame
+    # do something with public-channel frame
   end
 
   def handle_event({:ok, "private-channel", "some-other-event"}, frame) do
-    # do something with private frame
+    # do something with private-channel frame
   end
   
   # We can also catch errors.
@@ -97,6 +101,14 @@ config = %{
 
 ### Now you can use various functions injected in your module
 ```elixir
+SimpleClient.channels()
+# => %{
+"channels" => %{
+  "presence-init-channel" => %{},
+  "private-init-channel" => %{},
+  "public-init-channel" => %{}
+}
+# ...
 SimpleClient.subscribe("public-channel")
 :ok
 # ...
@@ -117,8 +129,9 @@ SimpleClient.presence()
 SimpleClient.trigger("private-channel", "first-event", %{message: "Ahoj"})
 :ok
 # ...
-SimpleClient.channels()
-["presence-channel", "private-channel", "public-channel"]
+SimpleClient.subscribed_channels()
+["presence-channel", "private-channel", "public-channel",
+ "presence-init-channel", "private-init-channel", "public-init-channel"]
 # ...
 SimpleClient.unsubscribe("public-channel")
 :ok
@@ -174,7 +187,7 @@ SimpleClient.channels()
 #### subscribed_channels/0
 Returns list of all the subscribed channels for current instance.
 ```elixir
-SimpleClient.channels()
+SimpleClient.subscribed_channels()
 ["private-channel"]
 ```
 
@@ -194,6 +207,37 @@ SimpleClient.presence()
 Unsubscribes from given channel
 ```elixir
 SimpleClient.unsubscribe("public-channel")
+```
+
+### Overridable functions
+These functions are meant to be overridden in a module using Pushest
+#### handle_event/2
+Callback being triggered when there is a WebSocket event on a subscribed channel.
+```elixir
+defmodule MyApp.MyModule
+  use Pushest, otp_app: :my_app
+
+  def handle_event({:ok, "my-channel", "my-event"}, frame) do
+    IO.inspect frame
+  end
+end
+```
+
+#### init_channels/0
+Subscribes to given list of channels right after application startup.
+Each element has to be a keyword list in exact format of: `[name: String.t(), user_data: map]`
+```elixir
+defmodule MyApp.MyModule
+  use Pushest, otp_app: :my_app
+
+  def init_channels do
+    [
+      [name: "public-init-channel", user_data: %{}],
+      [name: "private-init-channel", user_data: %{}],
+      [name: "presence-init-channel", user_data: %{user_id: 123}],
+    ]
+  end
+end
 ```
 
 #### `frame` example

--- a/lib/pushest.ex
+++ b/lib/pushest.ex
@@ -114,11 +114,11 @@ defmodule Pushest do
       """
       @spec start_link(pusher_opts) :: {:ok, pid} | {:error, term}
       def start_link(pusher_opts) when is_map(pusher_opts) do
-        Pushest.Supervisor.start_link(pusher_opts, __MODULE__)
+        Pushest.Supervisor.start_link(pusher_opts, __MODULE__, init_channels())
       end
 
       def start_link(_) do
-        Pushest.Supervisor.start_link(@config, __MODULE__)
+        Pushest.Supervisor.start_link(@config, __MODULE__, init_channels())
       end
 
       def child_spec(opts) do
@@ -127,6 +127,10 @@ defmodule Pushest do
           start: {__MODULE__, :start_link, [opts]},
           type: :supervisor
         }
+      end
+
+      def init_channels do
+        []
       end
 
       @doc ~S"""
@@ -221,7 +225,7 @@ defmodule Pushest do
         )
       end
 
-      defoverridable handle_event: 2
+      defoverridable handle_event: 2, init_channels: 0
     end
   end
 end

--- a/lib/pushest.ex
+++ b/lib/pushest.ex
@@ -2,13 +2,13 @@ defmodule Pushest do
   @moduledoc ~S"""
   Pushest is a Pusher library leveraging Elixir/OTP to combine server and client-side Pusher features.
   Abstracts un/subscription, client-side triggers, private/presence channel authorizations.
-  Keeps track of subscribed channels and users presence when subscribed to presence channel.
-  Pushest is meant to be used in your module where you can define callbacks for
+  Keeps track of subscribed channels and users presence when subscribed to a presence channel.
+  Pushest is meant to be `use`d in your module where you can define callbacks for
   events you're interested in.
 
   A simple implementation in an OTP application would be:
   ```
-  # Add necessary pusher configuration to your application config:
+  # Add necessary pusher configuration to your application config (assuming an OTP app):
   # simple_client/config/config.exs
   config :simple_client, SimpleClient,
     pusher_app_id: System.get_env("PUSHER_APP_ID"),
@@ -19,18 +19,33 @@ defmodule Pushest do
 
   # simple_client/simple_client.ex
   defmodule SimpleClient do
+    # :otp_app option is needed for Pushest to get a config.
     use Pushest, otp_app: :simple_client
 
+    # Subscribe to these channels right after application startup.
+    def init_channels do
+      [
+        [name: "public-init-channel", user_data: %{}],
+        [name: "private-init-channel", user_data: %{}],
+        [name: "presence-init-channel", user_data: %{user_id: 123}],
+      ]
+    end
+
+    # handle incoming events.
+    def handle_event({:ok, "public-init-channel", "some-event"}, frame) do
+      # do something with public-init-channel frame
+    end
+
     def handle_event({:ok, "public-channel", "some-event"}, frame) do
-      # do something with public frame
+      # do something with public-channel frame
     end
 
     def handle_event({:ok, "private-channel", "some-other-event"}, frame) do
-      # do something with private frame
+      # do something with private-channel frame
     end
   end
 
-  # Now you can start your application with Pushest as a part of your supervision tree:
+  # Now you can start your application as a part of your supervision tree:
   # simple_client/lib/simple_client/application.ex
   def start(_type, _args) do
     children = [
@@ -55,16 +70,22 @@ defmodule Pushest do
   {:ok, pid} = SimpleClient.start_link(config)
   ```
 
-  Now you can interact with Pusher:
+  Now you can interact with Pusher using methods injected in your module:
   ```
   SimpleClient.trigger("private-channel", "event", %{message: "via api"}) 
   SimpleClient.channels()
-  # => %{"channels" => %{"public-channel" => %{}}}
+  # => %{
+  "channels" => %{
+    "presence-init-channel" => %{},
+    "private-init-channel" => %{},
+    "public-init-channel" => %{}
+  }
   SimpleClient.subscribe("private-channel")
   SimpleClient.trigger("private-channel", "event", %{message: "via ws"}) 
   SimpleClient.trigger("private-channel", "event", %{message: "via api"}, force_api: true) 
   # ...
   ```
+  For full list of injected methods please check the README.
   """
 
   alias Pushest.Router
@@ -112,7 +133,6 @@ defmodule Pushest do
 
       For available pusher_opts values see `t:pusher_opts/0`.
       """
-      @spec start_link(pusher_opts) :: {:ok, pid} | {:error, term}
       def start_link(pusher_opts) when is_map(pusher_opts) do
         Pushest.Supervisor.start_link(pusher_opts, __MODULE__, init_channels())
       end
@@ -129,10 +149,6 @@ defmodule Pushest do
         }
       end
 
-      def init_channels do
-        []
-      end
-
       @doc ~S"""
       Subscribe to a channel with user_data as a map. When subscribing to a
       presence- channel user_id key with unique identifier as a value has to be
@@ -140,7 +156,6 @@ defmodule Pushest do
       informations about user.
       E.g.: %{user_id: "1", user_info: %{name: "Tomas Koutsky"}}
       """
-      @spec subscribe(String.t(), map) :: term
       def subscribe(channel, user_data) do
         Router.cast({:subscribe, channel, user_data})
       end
@@ -148,7 +163,6 @@ defmodule Pushest do
       @doc ~S"""
       Subscribe to a channel without any user data, like any public channel.
       """
-      @spec subscribe(String.t()) :: term
       def subscribe(channel) do
         Router.cast({:subscribe, channel, %{}})
       end
@@ -157,7 +171,6 @@ defmodule Pushest do
       Trigger on given channel/event combination - sends given data to Pusher.
       data has to be a map.
       """
-      @spec trigger(String.t(), String.t(), map) :: term
       def trigger(channel, event, data) do
         Router.cast({:trigger, channel, event, data})
       end
@@ -169,7 +182,6 @@ defmodule Pushest do
 
       For trigger_opts values see `t:trigger_opts/0`.
       """
-      @spec trigger(String.t(), String.t(), map, trigger_opts) :: term
       def trigger(channel, event, data, opts) do
         Router.cast({:trigger, channel, event, data}, opts)
       end
@@ -209,11 +221,35 @@ defmodule Pushest do
       defmodule MyMod do
         use Pushest, otp_app: :my_mod
 
+        def init_channels do
+          [
+            [name: "public-init-channel", user_data: %{}],
+            [name: "private-init-channel", user_data: %{}],
+            [name: "presence-init-channel", user_data: %{user_id: 123}],
+          ]
+        end
+      end
+      ```
+      Subscribes to given list of channels right after application startup.
+      Each element has to be a keyword list in exact format of:
+      [name: String.t(), user_data: map]
+      """
+      def init_channels do
+        []
+      end
+
+      @doc ~S"""
+      Function meant to be overwritten in user module, e.g.:
+      ```
+      defmodule MyMod do
+        use Pushest, otp_app: :my_mod
+
         handle_event({:ok, "my-channel, "my-event"}, frame) do
           # Do something with a frame here.
         end
       end
       ```
+      Catches events sent to a channels the client is subscribed to.
       """
       def handle_event({status, channel, event}, frame) do
         require Logger

--- a/lib/pushest/api.ex
+++ b/lib/pushest/api.ex
@@ -15,7 +15,7 @@ defmodule Pushest.Api do
   @client Pushest.Client.for_env()
   @version Mix.Project.config()[:version]
 
-  def start_link({pusher_opts, _callback_module}) do
+  def start_link({pusher_opts, _callback_module, _init_channels}) do
     GenServer.start_link(
       __MODULE__,
       %State{url: Utils.url(pusher_opts), options: %Options{} |> Map.merge(pusher_opts)},

--- a/lib/pushest/api.ex
+++ b/lib/pushest/api.ex
@@ -78,7 +78,7 @@ defmodule Pushest.Api do
   end
 
   def handle_info(
-        {:gun_response, conn_pid, stream_ref, :nofin, status, _headers},
+        {:gun_response, conn_pid, stream_ref, :fin, status, _headers},
         state = %State{conn_pid: conn_pid}
       ) do
     case status do

--- a/lib/pushest/socket.ex
+++ b/lib/pushest/socket.ex
@@ -184,9 +184,9 @@ defmodule Pushest.Socket do
     }
   end
 
+  @spec do_init_channels(list) :: term
   defp do_init_channels([[name: channel, user_data: user_data] | other_channels]) do
     GenServer.cast(__MODULE__, {:subscribe, channel, user_data})
-    Logger.debug("do_init_channels: #{channel}")
     do_init_channels(other_channels)
   end
 

--- a/lib/pushest/socket/data/state.ex
+++ b/lib/pushest/socket/data/state.ex
@@ -12,5 +12,6 @@ defmodule Pushest.Socket.Data.State do
             channels: [],
             presence: %Presence{},
             conn_pid: nil,
-            callback_module: nil
+            callback_module: nil,
+            init_channels: []
 end

--- a/lib/pushest/supervisor.ex
+++ b/lib/pushest/supervisor.ex
@@ -7,9 +7,13 @@ defmodule Pushest.Supervisor do
   alias Pushest.{Api, Socket}
   use Supervisor
 
-  @spec start_link(map, module) :: {:ok, pid} | {:error, term}
-  def start_link(pusher_opts, callback_module) do
-    Supervisor.start_link(__MODULE__, {pusher_opts, callback_module}, name: __MODULE__)
+  @spec start_link(map, module, list) :: {:ok, pid} | {:error, term}
+  def start_link(pusher_opts, callback_module, init_channels) do
+    Supervisor.start_link(
+      __MODULE__,
+      {pusher_opts, callback_module, init_channels},
+      name: __MODULE__
+    )
   end
 
   def init(opts) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Pushest.MixProject do
   def project do
     [
       app: :pushest,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/pushest_test.exs
+++ b/test/pushest_test.exs
@@ -12,6 +12,14 @@ defmodule PushestTest do
     @moduledoc false
 
     use Pushest, otp_app: :pushest
+
+    def init_channels do
+      [
+        [name: "public-init-channel", user_data: %{}],
+        [name: "private-init-channel", user_data: %{}],
+        [name: "presence-init-channel", user_data: %{user_id: 123}],
+      ]
+    end
   end
 
   def child_pid(mod_name) do
@@ -60,6 +68,14 @@ defmodule PushestTest do
 
   setup_all do
     start()
+  end
+
+  describe "subscription to init_channels" do
+    test "it subscribes to list of init_channels after startup" do
+      assert Enum.member?(TestPushest.subscribed_channels(), "public-init-channel")
+      assert Enum.member?(TestPushest.subscribed_channels(), "private-init-channel")
+      assert Enum.member?(TestPushest.subscribed_channels(), "presence-init-channel")
+    end
   end
 
   describe "subscribe" do


### PR DESCRIPTION
init_channels/0 allows to subscribe to given list of channels during the startup of your app.

Example:
```elixir
defmodule SimpleClient do
  use Pushest, otp_app: :simple_client

  def init_channels do
    [
      [name: "public-init-channel", user_data: %{}],
      [name: "private-init-channel", user_data: %{}],
      [name: "presence-init-channel", user_data: %{user_id: 123}],
    ]
  end
end
```

Each element of the list has to be a keyword list with `name` and `user_data` keys with values of following type: `[name: String.t(), user_data: map]`

Should there be a limit or a timeout after each subsequent subscription? We don't want to DoS Pusher with a list of 1000 elements.