### PR TITLE
0.2.3

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -84,7 +84,7 @@
         #
         {Credo.Check.Readability.FunctionNames},
         {Credo.Check.Readability.LargeNumbers},
-        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 80},
+        {Credo.Check.Readability.MaxLineLength, priority: :low, max_length: 100},
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc},
         {Credo.Check.Readability.ModuleNames},

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -2,6 +2,7 @@ PreCommit:
   Credo:
     enabled: true
     on_warn: fail
+    command: ['mix', 'credo']
   TrailingWhitespace:
     enabled: true
     on_warn: fail

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,7 @@
+PreCommit:
+  Credo:
+    enabled: true
+    on_warn: fail
+  TrailingWhitespace:
+    enabled: true
+    on_warn: fail

--- a/lib/pushest.ex
+++ b/lib/pushest.ex
@@ -99,7 +99,7 @@ defmodule Pushest do
     quote bind_quoted: [opts: opts] do
       @behaviour Pushest
 
-      @config Pushest.Supervisor.config(__MODULE__, opts)
+      @options Pushest.Supervisor.config(__MODULE__, opts)
 
       @doc ~S"""
       Starts a Pushest Supervisor process linked to current process.
@@ -114,7 +114,7 @@ defmodule Pushest do
       end
 
       def start_link(_) do
-        Pushest.Supervisor.start_link(@config, __MODULE__, init_channels())
+        Pushest.Supervisor.start_link(@options, __MODULE__, init_channels())
       end
 
       def child_spec(opts) do
@@ -133,14 +133,14 @@ defmodule Pushest do
       E.g.: %{user_id: "1", user_info: %{name: "Tomas Koutsky"}}
       """
       def subscribe(channel, user_data) do
-        Router.cast({:subscribe, channel, user_data})
+        Router.cast({:subscribe, channel, user_data}, @options)
       end
 
       @doc ~S"""
       Subscribe to a channel without any user data, like any public channel.
       """
       def subscribe(channel) do
-        Router.cast({:subscribe, channel, %{}})
+        Router.cast({:subscribe, channel, %{}}, @options)
       end
 
       @doc ~S"""
@@ -148,7 +148,7 @@ defmodule Pushest do
       data has to be a map.
       """
       def trigger(channel, event, data) do
-        Router.cast({:trigger, channel, event, data})
+        Router.cast({:trigger, channel, event, data}, @options)
       end
 
       @doc ~S"""
@@ -157,21 +157,21 @@ defmodule Pushest do
       E.g.: `Mod.trigger("channel", "event", %{message: "m"}, force_api: true)`
       """
       def trigger(channel, event, data, opts) do
-        Router.cast({:trigger, channel, event, data}, opts)
+        Router.cast({:trigger, channel, event, data}, @options, opts)
       end
 
       @doc ~S"""
       Returns all the channels anyone is using, calls Pusher via REST API.
       """
       def channels do
-        Router.call(:channels)
+        Router.call(:channels, @options)
       end
 
       @doc ~S"""
       Returns only the channels this client is subscribed to.
       """
       def subscribed_channels do
-        Router.call(:subscribed_channels)
+        Router.call(:subscribed_channels, @options)
       end
 
       @doc ~S"""
@@ -179,14 +179,14 @@ defmodule Pushest do
       this client is subscribed to.
       """
       def presence do
-        Router.call(:presence)
+        Router.call(:presence, @options)
       end
 
       @doc ~S"""
       Unsubscribes from a channel
       """
       def unsubscribe(channel) do
-        Router.cast({:unsubscribe, channel})
+        Router.cast({:unsubscribe, channel}, @options)
       end
 
       def authenticate(_channel, _socket_id) do

--- a/lib/pushest/adapter.ex
+++ b/lib/pushest/adapter.ex
@@ -1,0 +1,10 @@
+defmodule Pushest.Adapter do
+  @moduledoc ~S"""
+  Defines a public intefrace which should all the adapters follow.
+  """
+
+  @type call_resp :: map | list(String.t()) | :no_data | :error
+
+  @callback call(Pushest.Router.call_term()) :: call_resp
+  @callback cast(Pushest.Router.cast_term()) :: :ok
+end

--- a/lib/pushest/adapters/api.ex
+++ b/lib/pushest/adapters/api.ex
@@ -1,4 +1,4 @@
-defmodule Pushest.Api do
+defmodule Pushest.Adapters.Api do
   @moduledoc ~S"""
   GenServer responsible for communication with Pusher via REST API endpoint.
   This module is meant to be used internally as part of the Pushest application.
@@ -8,9 +8,11 @@ defmodule Pushest.Api do
 
   require Logger
 
-  alias __MODULE__.Utils
-  alias __MODULE__.Data.{State, Frame, Url}
+  alias Pushest.Api.Utils
+  alias Pushest.Api.Data.{State, Frame, Url}
   alias Pushest.Data.Options
+
+  @behaviour Pushest.Adapter
 
   @client Pushest.Client.for_env()
   @version Mix.Project.config()[:version]
@@ -25,6 +27,14 @@ defmodule Pushest.Api do
       %State{url: Utils.url(pusher_opts), options: %Options{} |> Map.merge(pusher_opts)},
       name: __MODULE__
     )
+  end
+
+  def call(command) do
+    GenServer.call(__MODULE__, command)
+  end
+
+  def cast(command) do
+    GenServer.cast(__MODULE__, command)
   end
 
   ## ==========================================================================
@@ -143,6 +153,7 @@ defmodule Pushest.Api do
 
       {:error, reason} ->
         Logger.error(":gun_fail #{inspect(reason)}")
+        :error
     end
   end
 end

--- a/lib/pushest/adapters/socket.ex
+++ b/lib/pushest/adapters/socket.ex
@@ -1,4 +1,4 @@
-defmodule Pushest.Socket do
+defmodule Pushest.Adapters.Socket do
   @moduledoc ~S"""
   GenServer responsible for communication with Pusher via WebSockets.
   This module is meant to be used internally as part of the Pushest application.
@@ -8,9 +8,11 @@ defmodule Pushest.Socket do
 
   use GenServer
 
-  alias __MODULE__.Utils
-  alias __MODULE__.Data.{State, Frame, Url, Presence, SocketInfo}
+  alias Pushest.Socket.Utils
+  alias Pushest.Socket.Data.{State, Frame, Url, Presence, SocketInfo}
   alias Pushest.Data.Options
+
+  @behaviour Pushest.Adapter
 
   @client Pushest.Client.for_env()
 
@@ -24,6 +26,14 @@ defmodule Pushest.Socket do
       init_state(opts),
       name: __MODULE__
     )
+  end
+
+  def call(command) do
+    GenServer.call(__MODULE__, command)
+  end
+
+  def cast(command) do
+    GenServer.cast(__MODULE__, command)
   end
 
   ## ==========================================================================

--- a/lib/pushest/adapters/socket.ex
+++ b/lib/pushest/adapters/socket.ex
@@ -143,20 +143,31 @@ defmodule Pushest.Adapters.Socket do
       "pusher_internal:subscription_succeeded" ->
         Logger.debug("Socket | pusher_internal:subscription_succeeded")
         presence = Presence.merge(presence, frame.data["presence"])
-        {:noreply, %{state | channels: [frame.channel | channels], presence: presence}}
+
+        {
+          :noreply,
+          %{state | channels: [frame.channel | channels], presence: presence}
+        }
 
       "pusher_internal:member_added" ->
         Logger.debug("Socket | pusher_internal:member_added")
-        {:noreply, %{state | presence: Presence.add_member(presence, frame.data)}}
+
+        {
+          :noreply,
+          %{state | presence: Presence.add_member(presence, frame.data)}
+        }
 
       "pusher_internal:member_removed" ->
         Logger.debug("Socket | pusher_internal:member_removed")
-        {:noreply, %{state | presence: Presence.remove_member(presence, frame.data)}}
+
+        {
+          :noreply,
+          %{state | presence: Presence.remove_member(presence, frame.data)}
+        }
 
       "pusher:error" ->
         message = Map.get(frame.data, "message")
         Logger.error(fn -> "Socket | pusher:error #{inspect(message)}" end)
-
         Pushest.Utils.try_callback(callback_module, :handle_event, [{:error, message}, frame])
         {:noreply, state}
 

--- a/lib/pushest/adapters/test_adapter.ex
+++ b/lib/pushest/adapters/test_adapter.ex
@@ -1,0 +1,15 @@
+defmodule Pushest.Adapters.TestAdapter do
+  @moduledoc ~S"""
+  Adapter meant to be used in tests.
+  """
+
+  @behaviour Pushest.Adapter
+
+  def call(_command) do
+    :no_data
+  end
+
+  def cast(_command) do
+    :ok
+  end
+end

--- a/lib/pushest/api.ex
+++ b/lib/pushest/api.ex
@@ -92,7 +92,9 @@ defmodule Pushest.Api do
     case status do
       200 ->
         {:ok, _body} = :gun.await_body(conn_pid, stream_ref)
-      _ -> Logger.error("Api | Pusher response status #{inspect(status)}")
+
+      _ ->
+        Logger.error("Api | Pusher response status #{inspect(status)}")
     end
 
     {:noreply, state}

--- a/lib/pushest/api/data/frame.ex
+++ b/lib/pushest/api/data/frame.ex
@@ -5,6 +5,12 @@ defmodule Pushest.Api.Data.Frame do
   This module handles encode/decode actions for a Frame.
   """
 
+  @type t :: %__MODULE__{
+          channel: String.t(),
+          name: String.t(),
+          data: map
+        }
+
   defstruct [:channel, :name, :data]
 
   @doc ~S"""

--- a/lib/pushest/api/data/state.ex
+++ b/lib/pushest/api/data/state.ex
@@ -6,5 +6,11 @@ defmodule Pushest.Api.Data.State do
   alias Pushest.Api.Data.Url
   alias Pushest.Data.Options
 
+  @type t :: %__MODULE__{
+          url: %Url{},
+          options: %Options{},
+          conn_pid: nil | pid
+        }
+
   defstruct url: %Url{}, options: %Options{}, conn_pid: nil
 end

--- a/lib/pushest/api/data/url.ex
+++ b/lib/pushest/api/data/url.ex
@@ -3,5 +3,10 @@ defmodule Pushest.Api.Data.Url do
   Structure used to construct URL for Pusher server.
   """
 
+  @type t :: %__MODULE__{
+          domain: String.t(),
+          port: integer
+        }
+
   defstruct [:domain, :port]
 end

--- a/lib/pushest/api/utils.ex
+++ b/lib/pushest/api/utils.ex
@@ -38,7 +38,12 @@ defmodule Pushest.Api.Utils do
       iex> Pushest.Api.Utils.full_path("GET", "events", %{app_id: "app_id", key: "key", secret: "secret"})
       "/apps/app_id/events?auth_key=key&auth_timestamp=123&auth_version=1.0&body_md5=d41d8cd98f00b204e9800998ecf8427e&auth_signature=7e4ff0027ba406a0c638ee08967c9d6e8d2e2485020e31a25118b57f5b50239a"
   """
-  def full_path(verb, path, %{app_id: app_id, key: key, secret: secret}, frame \\ "") do
+  def full_path(
+        verb,
+        path,
+        %{app_id: app_id, key: key, secret: secret},
+        frame \\ ""
+      ) do
     auth_timestamp = Timestamp.for_env()
 
     frame_md5 = :crypto.hash(:md5, frame) |> Base.encode16(case: :lower)
@@ -49,7 +54,9 @@ defmodule Pushest.Api.Utils do
         "auth_timestamp=#{auth_timestamp}&" <>
         "auth_version=#{@auth_version}&" <> "body_md5=#{frame_md5}"
 
-    auth_signature = :crypto.hmac(:sha256, secret, string_to_sign) |> Base.encode16(case: :lower)
+    auth_signature =
+      :crypto.hmac(:sha256, secret, string_to_sign)
+      |> Base.encode16(case: :lower)
 
     "/apps/#{app_id}/#{path}?" <>
       "auth_key=#{key}&" <>

--- a/lib/pushest/data/options.ex
+++ b/lib/pushest/data/options.ex
@@ -4,13 +4,23 @@ defmodule Pushest.Data.Options do
   initializating methods.
   """
 
+  alias Pushest.Adapters.{Api, Socket}
+
   @type t :: %__MODULE__{
           app_id: String.t(),
           key: String.t(),
           cluster: String.t(),
           secret: String.t(),
-          encrypted: boolean
+          encrypted: boolean,
+          api_adapter: module,
+          socket_adapter: module
         }
 
-  defstruct [:app_id, :key, :cluster, :encrypted, :secret]
+  defstruct app_id: "",
+            key: "",
+            cluster: "",
+            encrypted: false,
+            secret: "",
+            api_adapter: Api,
+            socket_adapter: Socket
 end

--- a/lib/pushest/data/options.ex
+++ b/lib/pushest/data/options.ex
@@ -4,5 +4,13 @@ defmodule Pushest.Data.Options do
   initializating methods.
   """
 
+  @type t :: %__MODULE__{
+          app_id: String.t(),
+          key: String.t(),
+          cluster: String.t(),
+          secret: String.t(),
+          encrypted: boolean
+        }
+
   defstruct [:app_id, :key, :cluster, :encrypted, :secret]
 end

--- a/lib/pushest/socket/data/frame.ex
+++ b/lib/pushest/socket/data/frame.ex
@@ -7,6 +7,12 @@ defmodule Pushest.Socket.Data.Frame do
 
   alias Pushest.Socket.Data.SubscriptionData
 
+  @type t :: %__MODULE__{
+    channel: String.t(),
+    event: String.t(),
+    data: map
+  }
+
   defstruct [:channel, :event, :data]
 
   @doc ~S"""

--- a/lib/pushest/socket/data/frame.ex
+++ b/lib/pushest/socket/data/frame.ex
@@ -8,10 +8,10 @@ defmodule Pushest.Socket.Data.Frame do
   alias Pushest.Socket.Data.SubscriptionData
 
   @type t :: %__MODULE__{
-    channel: String.t(),
-    event: String.t(),
-    data: map
-  }
+          channel: String.t(),
+          event: String.t(),
+          data: map
+        }
 
   defstruct [:channel, :event, :data]
 

--- a/lib/pushest/socket/data/presence.ex
+++ b/lib/pushest/socket/data/presence.ex
@@ -3,6 +3,13 @@ defmodule Pushest.Socket.Data.Presence do
   Structure representing presence information, connected user IDs and data of them.
   """
 
+  @type t :: %__MODULE__{
+    count: integer,
+    hash: map,
+    ids: list(integer),
+    me: map
+  }
+
   defstruct count: 0, hash: %{}, ids: [], me: %{}
 
   @doc ~S"""

--- a/lib/pushest/socket/data/presence.ex
+++ b/lib/pushest/socket/data/presence.ex
@@ -4,11 +4,11 @@ defmodule Pushest.Socket.Data.Presence do
   """
 
   @type t :: %__MODULE__{
-    count: integer,
-    hash: map,
-    ids: list(integer),
-    me: map
-  }
+          count: integer,
+          hash: map,
+          ids: list(integer),
+          me: map
+        }
 
   defstruct count: 0, hash: %{}, ids: [], me: %{}
 

--- a/lib/pushest/socket/data/socket_info.ex
+++ b/lib/pushest/socket/data/socket_info.ex
@@ -5,6 +5,11 @@ defmodule Pushest.Socket.Data.SocketInfo do
   This module handles decode action for a SocketInfo.
   """
 
+  @type t :: %__MODULE__{
+    socket_id: String.t(),
+    activity_timeout: integer
+  }
+
   defstruct [:socket_id, :activity_timeout]
 
   @doc ~S"""

--- a/lib/pushest/socket/data/socket_info.ex
+++ b/lib/pushest/socket/data/socket_info.ex
@@ -6,9 +6,9 @@ defmodule Pushest.Socket.Data.SocketInfo do
   """
 
   @type t :: %__MODULE__{
-    socket_id: String.t(),
-    activity_timeout: integer
-  }
+          socket_id: String.t(),
+          activity_timeout: integer
+        }
 
   defstruct [:socket_id, :activity_timeout]
 

--- a/lib/pushest/socket/data/state.ex
+++ b/lib/pushest/socket/data/state.ex
@@ -6,6 +6,19 @@ defmodule Pushest.Socket.Data.State do
   alias Pushest.Socket.Data.{SocketInfo, Url, Presence}
   alias Pushest.Data.Options
 
+  @type init_channel :: [name: String.t(), user_data: map]
+
+  @type t :: %__MODULE__{
+    url: %Url{},
+    options: %Options{},
+    socket_info: %SocketInfo{},
+    channels: list(string),
+    presence: %Presence{},
+    conn_pid: pid | nil,
+    callback_module: module | nil,
+    init_channels: list(init_channel)
+  }
+
   defstruct url: %Url{},
             options: %Options{},
             socket_info: %SocketInfo{},

--- a/lib/pushest/socket/data/state.ex
+++ b/lib/pushest/socket/data/state.ex
@@ -9,15 +9,15 @@ defmodule Pushest.Socket.Data.State do
   @type init_channel :: [name: String.t(), user_data: map]
 
   @type t :: %__MODULE__{
-    url: %Url{},
-    options: %Options{},
-    socket_info: %SocketInfo{},
-    channels: list(string),
-    presence: %Presence{},
-    conn_pid: pid | nil,
-    callback_module: module | nil,
-    init_channels: list(init_channel)
-  }
+          url: %Url{},
+          options: %Options{},
+          socket_info: %SocketInfo{},
+          channels: list(String.t()),
+          presence: %Presence{},
+          conn_pid: pid | nil,
+          callback_module: module | nil,
+          init_channels: list(init_channel)
+        }
 
   defstruct url: %Url{},
             options: %Options{},

--- a/lib/pushest/socket/data/subscription_data.ex
+++ b/lib/pushest/socket/data/subscription_data.ex
@@ -5,10 +5,10 @@ defmodule Pushest.Socket.Data.SubscriptionData do
   """
 
   @type t :: %__MODULE__{
-    channel: String.t(),
-    auth: String.t(),
-    channel_data: map
-  }
+          channel: String.t(),
+          auth: String.t(),
+          channel_data: map
+        }
 
   defstruct [:channel, :auth, :channel_data]
 end

--- a/lib/pushest/socket/data/subscription_data.ex
+++ b/lib/pushest/socket/data/subscription_data.ex
@@ -4,5 +4,11 @@ defmodule Pushest.Socket.Data.SubscriptionData do
   subscription event.
   """
 
+  @type t :: %__MODULE__{
+    channel: String.t(),
+    auth: String.t(),
+    channel_data: map
+  }
+
   defstruct [:channel, :auth, :channel_data]
 end

--- a/lib/pushest/socket/data/url.ex
+++ b/lib/pushest/socket/data/url.ex
@@ -3,5 +3,11 @@ defmodule Pushest.Socket.Data.Url do
   Structure used to construct URL for Pusher server.
   """
 
+  @type t :: %__MODULE__{
+    domain: String.t(),
+    path: String.t(),
+    port: integer
+  }
+
   defstruct [:domain, :path, :port]
 end

--- a/lib/pushest/socket/data/url.ex
+++ b/lib/pushest/socket/data/url.ex
@@ -4,10 +4,10 @@ defmodule Pushest.Socket.Data.Url do
   """
 
   @type t :: %__MODULE__{
-    domain: String.t(),
-    path: String.t(),
-    port: integer
-  }
+          domain: String.t(),
+          path: String.t(),
+          port: integer
+        }
 
   defstruct [:domain, :path, :port]
 end

--- a/lib/pushest/socket/utils.ex
+++ b/lib/pushest/socket/utils.ex
@@ -80,7 +80,10 @@ defmodule Pushest.Socket.Utils do
          user_data
        ) do
     signed = string_to_sign(socket_id, channel, user_data)
-    signature = :crypto.hmac(:sha256, secret, signed) |> Base.encode16(case: :lower)
+
+    signature =
+      :crypto.hmac(:sha256, secret, signed)
+      |> Base.encode16(case: :lower)
 
     "#{key}:#{signature}"
   end

--- a/lib/pushest/supervisor.ex
+++ b/lib/pushest/supervisor.ex
@@ -4,8 +4,10 @@ defmodule Pushest.Supervisor do
   for those modules.
   """
 
-  alias Pushest.{Api, Socket}
   use Supervisor
+
+  alias Pushest.Adapters.{Api, Socket}
+  alias Pushest.Data.Options
 
   @spec start_link(map, module, list) :: {:ok, pid} | {:error, term}
   def start_link(pusher_opts, callback_module, init_channels) do
@@ -41,14 +43,14 @@ defmodule Pushest.Supervisor do
     otp_app = Keyword.fetch!(opts, :otp_app)
     app_config = Application.get_env(otp_app, module, [])
 
-    pusher_config = %{
+    %Options{
       app_id: app_config[:pusher_app_id],
       key: app_config[:pusher_key],
       secret: app_config[:pusher_secret],
       cluster: app_config[:pusher_cluster],
-      encrypted: app_config[:pusher_encrypted]
+      encrypted: app_config[:pusher_encrypted],
+      api_adapter: app_config[:api_adapter] || Api,
+      socket_adapter: app_config[:socket_adapter] || Socket
     }
-
-    pusher_config
   end
 end

--- a/test/pushest/api/data/frame_test.exs
+++ b/test/pushest/api/data/frame_test.exs
@@ -1,4 +1,6 @@
 defmodule Pushest.Api.Data.FrameTest do
+  @moduledoc false
+
   use ExUnit.Case, async: true
   doctest Pushest.Api.Data.Frame
 end

--- a/test/pushest/socket/data/frame_test.exs
+++ b/test/pushest/socket/data/frame_test.exs
@@ -22,6 +22,7 @@ defmodule Pushest.Socket.Data.FrameTest do
         channel: nil
       }
 
+      # credo:disable-for-lines:4
       expected_frame =
         "{\"event\":\"pusher:subscribe\",\"data\":{\"channel_data\":\"{\\\"user_info\\\":{" <>
           "\\\"name\\\":\\\"Tomas Koutsky\\\",\\\"email\\\":\\\"secret@secret.com\\\"}," <>

--- a/test/pushest_test.exs
+++ b/test/pushest_test.exs
@@ -17,7 +17,7 @@ defmodule PushestTest do
       [
         [name: "public-init-channel", user_data: %{}],
         [name: "private-init-channel", user_data: %{}],
-        [name: "presence-init-channel", user_data: %{user_id: 123}],
+        [name: "presence-init-channel", user_data: %{user_id: 123}]
       ]
     end
   end

--- a/test/pushest_test.exs
+++ b/test/pushest_test.exs
@@ -44,8 +44,8 @@ defmodule PushestTest do
     {:ok, test_pushest_pid} = TestPushest.start_link(@pusher_config)
     Application.ensure_all_started(:pushest)
 
-    api_pid = child_pid(Pushest.Api)
-    socket_pid = child_pid(Pushest.Socket)
+    api_pid = child_pid(Pushest.Adapters.Api)
+    socket_pid = child_pid(Pushest.Adapters.Socket)
 
     FakeClient.establish_connection()
 

--- a/test/pushest_test.exs
+++ b/test/pushest_test.exs
@@ -6,6 +6,8 @@ defmodule PushestTest do
 
   import ExUnit.CaptureLog
 
+  alias Mix.Project
+
   alias Pushest.FakeClient
 
   defmodule TestPushest do
@@ -87,6 +89,7 @@ defmodule PushestTest do
 
       {:ok, frame} = FakeClient.last_frame()
 
+      # credo:disable-for-next-line
       assert frame[:payload] ==
                ~s({"event":"pusher:subscribe","data":{"channel_data":"{}","channel":"test-channel","auth":null},"channel":null})
 
@@ -131,6 +134,7 @@ defmodule PushestTest do
 
       {:ok, frame} = FakeClient.last_frame()
 
+      # credo:disable-for-lines:4
       assert frame[:payload] ==
                "{\"event\":\"pusher:subscribe\",\"data\":{\"channel_data\":\"{\\\"user_id\\\":\\\"1\\\"}\",\"channel\":\"#{
                  @channel
@@ -183,6 +187,7 @@ defmodule PushestTest do
 
       assert frame[:via] == :api
 
+      # credo:disable-for-lines:4
       assert frame[:payload] ==
                "{\"name\":\"event\",\"data\":\"{\\\"message\\\":\\\"message\\\"}\",\"channel\":\"#{
                  @channel
@@ -210,17 +215,19 @@ defmodule PushestTest do
 
       assert frame[:via] == :api
 
+      # credo:disable-for-lines:4
       assert frame[:payload] ==
                "{\"name\":\"event\",\"data\":\"{\\\"message\\\":\\\"message\\\"}\",\"channel\":\"#{
                  @channel
                }\"}"
 
+      # credo:disable-for-lines:2
       assert frame[:path] ==
                '/apps/PUSHER_APP_ID/events?auth_key=PUSHER_APP_KEY&auth_timestamp=123&auth_version=1.0&body_md5=d1f9b8b45be3308f990149da9e0a5868&auth_signature=98b6de3c177e917375dc4e8a7cca9d2fb2be5cdd9fe61b0231853211cc0a452c'
 
       assert frame[:headers] == [
                {"content-type", "application/json"},
-               {"X-Pusher-Library", "Pushest #{Mix.Project.config()[:version]}"}
+               {"X-Pusher-Library", "Pushest #{Project.config()[:version]}"}
              ]
     end
   end
@@ -237,17 +244,19 @@ defmodule PushestTest do
 
       assert frame[:via] == :api
 
+      # credo:disable-for-lines:4
       assert frame[:payload] ==
                "{\"name\":\"event\",\"data\":\"{\\\"message\\\":\\\"message\\\"}\",\"channel\":\"#{
                  @channel
                }\"}"
 
+      # credo:disable-for-lines:2
       assert frame[:path] ==
                '/apps/PUSHER_APP_ID/events?auth_key=PUSHER_APP_KEY&auth_timestamp=123&auth_version=1.0&body_md5=5ffd220c430c1e3e171458c14e9c3be9&auth_signature=ac41c93da2ae66aece34518f92b27386b92e19b628e78e2384460057c299f4ba'
 
       assert frame[:headers] == [
                {"content-type", "application/json"},
-               {"X-Pusher-Library", "Pushest #{Mix.Project.config()[:version]}"}
+               {"X-Pusher-Library", "Pushest #{Project.config()[:version]}"}
              ]
     end
   end
@@ -268,11 +277,12 @@ defmodule PushestTest do
 
       assert frame[:via] == :api
 
+      # credo:disable-for-lines:2
       assert frame[:path] ==
                '/apps/PUSHER_APP_ID/channels?auth_key=PUSHER_APP_KEY&auth_timestamp=123&auth_version=1.0&body_md5=d41d8cd98f00b204e9800998ecf8427e&auth_signature=fc8411aa6951f2065c7e56ed91a465dc2666efc2e8d756dd1c1024e6c3cfe7ab'
 
       assert frame[:headers] == [
-               {"X-Pusher-Library", "Pushest #{Mix.Project.config()[:version]}"}
+               {"X-Pusher-Library", "Pushest #{Project.config()[:version]}"}
              ]
     end
   end

--- a/test/support/fake_client.ex
+++ b/test/support/fake_client.ex
@@ -110,7 +110,7 @@ defmodule Pushest.FakeClient do
         }
       })
 
-    send(Pushest.Socket, {:gun_ws, self(), {:text, response}})
+    send(Pushest.Adapters.Socket, {:gun_ws, self(), {:text, response}})
 
     {:reply, :ok, state}
   end
@@ -146,7 +146,7 @@ defmodule Pushest.FakeClient do
             }
           })
 
-        send(Pushest.Socket, {:gun_ws, self(), {:text, response}})
+        send(Pushest.Adapters.Socket, {:gun_ws, self(), {:text, response}})
 
       "pusher:unsubscribe" when fail_unsubscribe ->
         response =
@@ -158,7 +158,7 @@ defmodule Pushest.FakeClient do
             }
           })
 
-        send(Pushest.Socket, {:gun_ws, self(), {:text, response}})
+        send(Pushest.Adapters.Socket, {:gun_ws, self(), {:text, response}})
 
       _ ->
         nil

--- a/test/support/fake_client.ex
+++ b/test/support/fake_client.ex
@@ -3,7 +3,7 @@ defmodule Pushest.FakeClient do
 
   use GenServer
 
-  def start_link() do
+  def start_link do
     GenServer.start_link(
       __MODULE__,
       %{
@@ -86,7 +86,11 @@ defmodule Pushest.FakeClient do
   end
 
   def handle_call(:reset_presence, _from, state) do
-    {:reply, :ok, Map.merge(state, %{presence: %{count: 0, hash: %{}, ids: []}})}
+    {
+      :reply,
+      :ok,
+      Map.merge(state, %{presence: %{count: 0, hash: %{}, ids: []}})
+    }
   end
 
   def handle_call(:await_up, _from, state = %{await_up: status}) do


### PR DESCRIPTION
## TODO
- [x] Types for struct
- [ ] Tests support
Refactor `Api` and `Socket`, add a possibility to set Api and Socket adapter via config.
Need to change `Supervisor` and `Router`.
Add TestAdapter to support testing in applications using `Pushest`.
Add examples of such a test.
- [ ] Expose `auth` function

## Tests support
When an OTP app is using Pushest it's currently not possible to test that app without maintaining a real connection to Pusher. It needs to be fixed.
The idea is to move `Api` and `Socket` modules to a `Adapters` namespace, introduce `Adapter` behaviour and `TestAdapter` adapter meant to be used in user-defined tests. It should be possible to introduce basic frame received assertion.

To set up such a tests user has to configure adapters in the test config.
```elixir
# config/config.test.exs
config :simple_client, SimpleClient,
  api_adater: Pushest.TestAdapter,
  socket_adapter: Pushest.TestAdapter
```
Those two adapters wont maintain any connection to any real server.
Then in a test
```elixir
defmodule SimpleClientTest do
  use ExUnit.Case
  use Pushest.Test

  test "sends a frame" do
    frame = %{...}

    SimpleClient.trigger("channel", "event", frame)

    assert_sent_frame frame
  end
end
```